### PR TITLE
Add handles, round avatars, spacing, interactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Thank you builder
 
-At GitHub, we like to say thanks to all the folks on our teams that helped with a particular feature launch. This website uses one of GitHub's coolest tricks to help you build out a quick grid of photos with all the people you choose on it. 
+At GitHub, we like to say thanks to all the folks on our teams that helped with a particular feature launch. This website uses one of GitHub's coolest tricks to help you build out a quick grid of photos with all the people you choose on it.
 
-<img width="1201" alt="Screen Shot 2020-04-22 at 3 13 52 PM" src="https://user-images.githubusercontent.com/12853539/80039119-eeddaa80-84ab-11ea-80ba-0abb506c0b20.png">
+<img width="1201" alt="Screen Shot 2020-04-22 at 3 13 52 PM" src="https://user-images.githubusercontent.com/110275/126683652-75d7ce6f-2758-4f3b-96e2-23807fbaae95.png">
 
-To use, clone the repository, then fill out the `users` array with the GitHub handles of all the people you're looking to thank. You can adjust the inline CSS to change the size of the photos, or background color to suit your needs. Then just screenshot the results and paste into your slides. :tada:
+To use, clone the repository, open the .html file, and fill the text box with the GitHub handles of all the people you're looking to thank. You can use your browser's zoom (cmd +/- on a Mac) to change the size of the photos, or use the browser's dev tools to change the background color to suit your needs. Checking "Square grid" uses a more compressed layout that omits handles and shows square avatars. Then just screenshot the results and paste into your slides. :tada:

--- a/thankyou.html
+++ b/thankyou.html
@@ -1,30 +1,74 @@
-<html>
-<style>
-  .thumb {
-    max-width:100px;
-    max-height:100px;
-  }
-  body {
-    background-color: black;
-  }
-</style>
+<!DOCTYPE html>
+<html lang="en">
 
+<head>
+  <style>
+    body {
+      color: #fff;
+      background-color: #000000;
+      text-align: center;
+      font-family: Inter, Helvetica, sans-serif;
+    }
 
+    #handles-input {
+      width: 90%;
+    }
+
+    .people {
+      display: flex;
+      flex-wrap: wrap;
+      margin: 30px;
+    }
+
+    .person {
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      margin: 20px;
+      width: 250px;
+    }
+
+    .person .avatar {
+      width: 150px;
+      height: 150px;
+      display: block;
+      border-radius: 75px;
+      border: 3px solid #fff;
+      box-sizing: border-box;
+      margin: 10px;
+    }
+
+    .person .name {
+      font-family: Inter;
+      font-weight: 500;
+      font-size: 28px;
+    }
+
+    .square-grid .person {
+      width: inherit;
+      margin: 0;
+    }
+
+    .square-grid .avatar {
+      border-radius: 0;
+      border: none;
+      margin: 0;
+    }
+
+    .square-grid .name {
+      display: none;
+    }
+  </style>
+
+  <script src="thankyou.js" type="text/javascript"></script>
 
 <body>
-
-
+  <div>
+    <textarea id="handles-input">octocat, hubot, github</textarea>
+    <br />
+    <label>Square grid <input id="grid-mode" type="checkbox"></label>
+  </div>
+  <div class="people"></div>
 </body>
-<script>
-  const users = ["octocat", "github"]
-  users.forEach(function (user){
-    var img = document.createElement("img");
-    img.src = "https://github.com/" + user + ".png";
-    img.classList.add("thumb");
-    document.body.appendChild(img)
-  });
-
-</script>
-
 
 </html>

--- a/thankyou.js
+++ b/thankyou.js
@@ -1,0 +1,39 @@
+function debounce(f) {
+  let timer = null;
+  return function () {
+    const context = this, args = arguments;
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      f.apply(context, args);
+    }, 500);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  const people = document.querySelector('.people');
+  const gridMode = document.getElementById('grid-mode');
+  gridMode.addEventListener('change', function () {
+    people.classList.toggle('square-grid');
+  });
+
+  const handlesInput = document.getElementById('handles-input');
+  const updateAvatars = () => {
+    const handles = handlesInput.value
+      .split(/[,\s]+/)
+      .map(h => h.trim().toLowerCase())
+      .filter(h => h.length > 0)
+      .sort();
+
+    people.innerHTML = handles.map(function (avatar) {
+      return `
+        <div class="person">
+          <img class="avatar" src="https://github.com/${avatar}.png" alt="avatar" />
+          <div class="name">@${avatar}</div>
+        </div>
+      `;
+    }).join('\n');
+  };
+
+  handlesInput.addEventListener('keyup', debounce(updateAvatars));
+  updateAvatars({ target: handlesInput });
+});


### PR DESCRIPTION
I made a few changes to the default layout:
- avatars are now round
- there's more spacing between avatars
- we also show the github handles / usernames

You can get back to the more compact layout by clicking the checkbox.

Additionally, the grid now updates when you type in the text box, so you don't need to edit JS & HTML. A nice side effect of this is that it should work with GitHub Pages now. Just rename the HTML file to `index.html`, turn on GitHub Pages, and it should be good to go?